### PR TITLE
Use new HSMP driver sysfs interface

### DIFF
--- a/include/e_smi/e_smi_monitor.h
+++ b/include/e_smi/e_smi_monitor.h
@@ -71,6 +71,11 @@
 #define CPU_PATH "/sys/devices/system/cpu"
 
 /**
+ * @brief HSMP sysfs directory.
+ */
+#define HSMP_PATH "/sys/devices/platform"
+
+/**
  * MONITOR TYPES
  * @brief This enum gives information to identify whether the monitor type is
  * from Energy/HWMON or HSMP.

--- a/src/e_smi.c
+++ b/src/e_smi.c
@@ -238,12 +238,12 @@ static esmi_status_t create_energy_monitor(void)
  */
 static esmi_status_t create_hsmp_monitor(void)
 {
-	if (find_hsmp(CPU_PATH) != 0) {
+	if (find_hsmp(HSMP_PATH) != 0) {
 		return ESMI_NO_HSMP_DRV;
 	}
 
 	snprintf(hsmpmon_path, sizeof(hsmpmon_path),
-		 "%s/"HSMP_DEV_NAME, CPU_PATH);
+		 "%s/"HSMP_DEV_NAME, HSMP_PATH);
 
 	return ESMI_SUCCESS;
 }


### PR DESCRIPTION
Sysfs interface of the HSMP driver was changed in the commit
f1859fae8b19e9704ea98fceafdcfdb5a8a7db0b
("Make amd_hsmp a platform driver").
Now the HSMP driver is a platfrom driver and the sysfs path
for it is needed to be changed.

Signed-off-by: Konstantin Aladyshev <aladyshev22@gmail.com>