### PR TITLE
Fix finding the amd_hsmp.h include file on RHEL systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(${E_SMI}_VERSION_MINOR "${VERSION_MINOR}")
 message("SOVERSION: ${SO_VERSION_STRING}")
 
 set(DEB_INC "/usr/include/x86_64-linux-gnu/asm/amd_hsmp.h")
-set(RHEL_INC "/usr/include/amd_hsmp.h")
+set(RHEL_INC "/usr/include/asm/amd_hsmp.h")
 string(ASCII 27 Esc)
 set(Magenta "${Esc}[35m")
 


### PR DESCRIPTION
This header is in /usr/include/asm on both RHEL/CentOS Stream and on Fedora

(Whether it is new enough is another matter though - with 4.1.2 the 6.13.6 in Fedora 41 is too old but the 6.14.0 rc6 in Fedora 42 works)