### PR TITLE
cmake: add pkg-config support for e-smi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,4 +267,16 @@ set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE
 set(CPACK_RPM_PACKAGE_NAME  ${E_SMI_PACKAGE})
 set(CPACK_RPM_PACKAGE_VERSION ${PKG_VERSION_STR})
 
+
+# Generate package config file
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/e_smi.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${E_SMI_PACKAGE}.pc
+    @ONLY
+)
+
+# Install package config file
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${E_SMI_PACKAGE}.pc
+	DESTINATION ${E_SMI}/lib/pkgconfig)
+
 include (CPack)

--- a/e_smi.pc.in
+++ b/e_smi.pc.in
@@ -1,0 +1,11 @@
+prefix=@CPACK_PACKAGING_INSTALL_PREFIX@
+exec_prefix=${prefix}/@E_SMI@
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: @CPACK_PACKAGE_NAME@
+Description: @CPACK_PACKAGE_DESCRIPTION_SUMMARY@
+Version: @CPACK_PACKAGE_VERSION@
+
+Libs: -L${libdir} -l@E_SMI_TARGET@
+Cflags: -I${includedir}


### PR DESCRIPTION
Generate and install a pkg-config(*.pc) file for e-smi.

The .pc file exposes include and library paths via pkg-config, allowing downstream projects (like DPDK) to link against e-smi without hardcoding build flags.