### PR TITLE
e_smi: fix const correctness for string literal arrays

### DIFF
--- a/include/e_smi/e_smi.h
+++ b/include/e_smi/e_smi.h
@@ -172,7 +172,7 @@ struct dpm_level {
 /**
  * @brief frequency limit source names
  */
-static char* const freqlimitsrcnames[] = {
+static const char* const freqlimitsrcnames[] = {
 	"cHTC-Active",
 	"PROCHOT",
 	"TDC Limit (CPU rail)",
@@ -189,7 +189,7 @@ static char* const freqlimitsrcnames[] = {
 /**
  * @brief SVI3 VR controller PLANE to SVI3_Rail_Index mapping for HSMP
  */
-static char* const svi3_rail_index_names[] = {
+static const char* const svi3_rail_index_names[] = {
 	"VDDCR_CPU0",
 	"VDDCR_CPU1",
 	"VDDCR_SOC",


### PR DESCRIPTION
String literals in C are of type `const char *`, but the arrays `freqlimitsrcnames` and `svi3_rail_index_names` were declared as `char * const`, which implies mutable data. This results in compiler warnings:

  warning: initialization discards ‘const’ qualifier

Update both arrays to `const char * const` to correctly reflect that:
- the string data is immutable
- the array pointers are not reassigned

This fixes -Wdiscarded-qualifiers warnings and improves const-correctness.