### PR TITLE
lib: Return error when computed socket count is zero

### DIFF
--- a/src/e_smi.c
+++ b/src/e_smi.c
@@ -376,6 +376,10 @@ static esmi_status_t detect_packages(struct system_metrics *psm)
 	/* Number of sockets in the system */
 	psm->total_sockets = psm->total_cores / max_cores_socket;
 
+	/* Avoid the malloc(0) and out-of-bounds write in create_cpu_mappings(). */
+	if (psm->total_sockets == 0)
+		return ESMI_NOT_SUPPORTED;
+
 	return ESMI_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary

`detect_packages()` computes `total_sockets = total_cores / max_cores_socket`, where `max_cores_socket` is the per-socket core capacity read from CPUID `0x80000008` (family `0x1A`, models `0x00`-`0x1F` / `0x50`-`0x5F`). When fewer cores are online than that reported capacity, the integer division truncates `total_sockets` to `0`.

`create_cpu_mappings()` then calls `malloc(total_sockets * sizeof(...))` == `malloc(0)` for the socket map and writes past the zero-size allocation while parsing `/proc/cpuinfo`, corrupting the heap and crashing with `SIGSEGV` inside `esmi_init()`.

This adds a guard that returns `ESMI_NOT_SUPPORTED` when the computed socket count is `0`, so `esmi_init()` fails cleanly and the caller can skip CPU initialization instead of crashing. It mirrors the adjacent `max_cores_socket == 0` guard.

## Test

- Verified the library builds cleanly with the change.
- On an affected system, `esmi_init()` now returns `ESMI_NOT_SUPPORTED` instead of crashing.